### PR TITLE
Fix undefined error when desc is absent

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,9 +16,10 @@ function getImage(req, res, next) {
     } else {
       var xmlDoc = libxmljs.parseXml(bingXml);
       response.imageUrl = "http://bing.com" + xmlDoc.get("//url").text();
-      response.copyright = xmlDoc.get("//copyright").text();
-      response.copyrightLink = xmlDoc.get("//copyrightlink").text();
-      response.description = xmlDoc.get("//desc").text();
+      var chunk;
+      response.copyright     = (chunk = xmlDoc.get("//copyright")? chunk.text(): '');
+      response.copyrightLink = (chunk = xmlDoc.get("//copyrightlink")? chunk.text(): '');
+      response.description   = (chunk = xmlDoc.get("//desc")? chunk.text(): '');
     }
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "X-Requested-With");


### PR DESCRIPTION
Today I found myself with this error
`{"code":"InternalError","message":"Cannot call method 'text' of undefined"}`

I suspect is because the `<desc />` field is absent from today's xml

```
<images>
<image>
<startdate>20160401</startdate>
<fullstartdate>201604010000</fullstartdate>
<enddate>20160402</enddate>
<url>
/az/hprichbg/rb/PuffinRock_ROW10720848382_1366x768.jpg
</url>
<urlBase>/az/hprichbg/rb/PuffinRock_ROW10720848382</urlBase>
<copyright>Puffins (© Nicram Sabod/Shutterstock)</copyright>
<copyrightlink>javascript:void(0)</copyrightlink>
<copyrightsource>© Nicram Sabod/Shutterstock</copyrightsource>
<drk>1</drk>
<top>1</top>
<bot>1</bot>
<hotspots/>
<messages/>
</image>
<tooltips>
<loadMessage>
<message>Loading...</message>
</loadMessage>
<previousImage>
<text>Previous</text>
</previousImage>
<nextImage>
<text>Next</text>
</nextImage>
<play>
<text>Play</text>
</play>
<pause>
<text>Pause</text>
</pause>
</tooltips>
</images>
```

I believe this PR fixes it.